### PR TITLE
#206 first redux form fix

### DIFF
--- a/frontend/containers/form/ChildrenDisplay.js
+++ b/frontend/containers/form/ChildrenDisplay.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import BasicFieldComponent from './BasicFieldComponent';
 
 const ChildrenDisplay = ({children}) => <div>{children}</div>;
 
@@ -7,4 +8,4 @@ ChildrenDisplay.propTypes = {
     children: PropTypes.node.isRequired,
 };
 
-export default ChildrenDisplay;
+export default BasicFieldComponent()(ChildrenDisplay);

--- a/frontend/containers/form/SelectField.js
+++ b/frontend/containers/form/SelectField.js
@@ -1,6 +1,5 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
-import BasicFieldComponent from './BasicFieldComponent';
 import ChildrenDisplay from './ChildrenDisplay';
 import selectFieldContextType from './selectFieldContextType';
 
@@ -15,7 +14,7 @@ class SelectField extends Component {
     }
 
     render() {
-        return React.createElement(BasicFieldComponent()(ChildrenDisplay), this.props, this.props.children);
+        return React.createElement(ChildrenDisplay, this.props, this.props.children);
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "react-scroll": "1.5.5",
     "react-spinkit": "3.0.0",
     "redux": "3.7.2",
-    "redux-form": "7.0.4",
+    "redux-form": "7.1.1",
     "redux-immutable": "4.0.0",
     "redux-saga": "0.16.0",
     "sprintf-js": "1.1.1",


### PR DESCRIPTION
fixes #206 

Tohle si asi vyžaduje vysvětlení. Alespoň tak, jak to chápu já, v `SelectField` se při každém renderu vytvářela `BasicFieldComponent()(ChildDisplay)`, takže pokaždé to byla jiná komponenta a triggerovalo to re-render `SelectOption`. Ten pak z nějakého důvodu (upgrade redux-form asi) triggeroval re-render `SelectField` a zacyklilo se to úplně.

Tím, že jsem z `BasicFieldComponent()(ChildDisplay)` udělal vlastní komponentu, která je pořád stejná, tak by k tomuhle nemělo docházet (otestováno).

Teoreticky to není 100% ideální, ale neměly by tam být výrazné problémy.